### PR TITLE
Made TTTPlayerGiveWeapons run about 6 times faster

### DIFF
--- a/gamemode/sv_spawning.lua
+++ b/gamemode/sv_spawning.lua
@@ -14,11 +14,16 @@ function GM:TTTPlayerGiveWeapons(ply)
 		[2] = true
 	}
 
+	local slots_left = table.Count(slots_needed)
+
 	for _, wep in RandomPairs(weapons.GetList()) do
 		if (wep.AutoSpawnable and slots_needed[wep.Slot]) then
 			ply:Give(wep.ClassName)
 			slots_needed[wep.Slot] = nil
-			continue
+			slots_left = slots_left - 1
+			if slots_left == 0 then
+				break
+			end
 		end
 	end
 end


### PR DESCRIPTION
This loop ran 38 times for each player in default tttrw and I imagine it would run many more times per player on servers with extra weapons. Making it break after the relevant slots were filled reduced it to about 6 loops per player. Especially for server with lots of extra weapons, this could help save on performance.