### PR TITLE
Settings Menu Padding

### DIFF
--- a/gamemode/vgui/ttt_settings.lua
+++ b/gamemode/vgui/ttt_settings.lua
@@ -111,7 +111,7 @@ function PANEL:Init()
 	self.Index = 1
 	self:Dock(TOP)
 
-	self:DockPadding(0, 0, 0, 0)
+	self:DockPadding(0, 0, 8, 0)
 end
 
 function PANEL:SetText(t)


### PR DESCRIPTION
Simply added padding to the settings menu so that the scroll bar stopped overlapping with the settings elements. Two commits because I did DockPadding(0, 0, 0, 0) the first time like a monkey

Visually: Changed https://i.imgur.com/ySkQxv0.png to https://i.imgur.com/aCGj1EX.png