### PR TITLE
Made team chat more compatible with custom roles

### DIFF
--- a/gamemode/sv_chat.lua
+++ b/gamemode/sv_chat.lua
@@ -85,7 +85,7 @@ function GM:PlayerSay(ply, text, team)
 		end
 	end
 
-	if (team and (not ply:Alive() or ttt.GetRoundState() ~= ttt.ROUNDSTATE_ACTIVE or ply:GetRole() == "Innocent")) then
+	if (team and (not ply:Alive() or ttt.GetRoundState() ~= ttt.ROUNDSTATE_ACTIVE or not ply:GetRoleData().TeamChatCanBeSeenBy)) then
 		ply:Say(text, false)
 
 		return ""


### PR DESCRIPTION
Having ply:GetRole() == "Innocent" works perfectly fine for default tttrw, but changing that to not ply:GetRoleData().TeamChatCanBeSeenBy adds compatibility for custom roles that don't use team chat.