### PR TITLE
Stopped body check attempts if the body menu is already open

### DIFF
--- a/gamemode/sh_init.lua
+++ b/gamemode/sh_init.lua
@@ -141,7 +141,7 @@ function GM:KeyPress(ply, key)
 		self:VoiceKey(ply, key)
 	end
 
-	if (CLIENT and key == IN_USE_ALT and self:TryInspectBody(ply)) then
+	if (CLIENT and key == IN_USE_ALT and not IsValid(ttt.InspectMenu) and self:TryInspectBody(ply)) then
 		return
 	end
 


### PR DESCRIPTION
If a player silently opened identified a body and then pressed IN_USE again to close the inspect menu (which is how most people do it) they would end up identifying the body, which defeats the purpose of silently identifying it in the first place. This check makes sure there isn't already an inspect menu open so that that doesn't happen.