### PR TITLE
Add was_burned tag to flare gun

### DIFF
--- a/entities/weapons/weapon_ttt_flaregun.lua
+++ b/entities/weapons/weapon_ttt_flaregun.lua
@@ -135,9 +135,15 @@ function IgniteTarget(att, path, dmginfo)
 			timer.Simple(dur + 0.1, function()
 				if IsValid(ent) then
 					ent.ignite_info = nil
+					ent.was_burned = nil
 				end
 			end)
 
+			ent.was_burned = {
+				att = att,
+				t = CurTime(),
+				wep = att:GetActiveWeapon():GetClass()
+			}
 		elseif ent:GetClass() == "prop_ragdoll" then
 			ScorchUnderRagdoll(ent)
 


### PR DESCRIPTION
Similar to was_pushed, which allows us to find the killer of someone who pushed someone else off a high ledge. https://github.com/meepen/tttrw/blob/25418d0830a0da7f84bcf672844c79a15be64e5c/entities/weapons/weapon_ttt_crowbar.lua#L282-L286

was_burned does the same thing except with the flare gun, since someone who burns to death via flare gun doesn't have a killer attributed.