### PR TITLE
Add a body identification hook

### DIFF
--- a/gamemode/sh_body.lua
+++ b/gamemode/sh_body.lua
@@ -174,6 +174,8 @@ function GM:TTTRWPlayerInspectBody(ply, ent, pos, is_silent)
 				return
 			end
 
+			hook.Run("TTTBodyIdentified", victim, ply)
+
 			for _, oply in ipairs(victim.Killed) do
 				if (IsValid(oply) and not oply:GetConfirmed()) then
 					oply:SetConfirmed(true)


### PR DESCRIPTION
 - Add TTTBodyIdentified that runs when a player's body is identified for the first time, saying who was identified and who identified it