### PR TITLE
Allows Easy Modification of Grenades via Weapon Properties.

### DIFF
--- a/entities/entities/ttt_basegrenade.lua
+++ b/entities/entities/ttt_basegrenade.lua
@@ -201,14 +201,26 @@ function ENT:Explode()
 	effect:SetStart(pos)
 	effect:SetOrigin(pos)
 	effect:SetScale(100)
-	effect:SetRadius(255)
+	effect:SetRadius(255 * self:GetRangeMulti())
 	effect:SetMagnitude(1)
 
 	util.Effect("Explosion", effect, true, true)
 
-	util.BlastDamage(self, self:GetOwner(), pos, 255, 50)
+	util.BlastDamage(self, self:GetOwner(), pos, (255 * self:GetRangeMulti()), (50 * self:GetDamageMulti()))
 
 	self:StartFires(pos, 10, 15, false, self:GetOwner())
 
 	--self:SetDetonateExact(0)
+end
+
+function ENT:GetDamageMulti()
+    if self.WeaponData == nil then return 1 end
+    if self.WeaponData.DamageMulti == nil then return 1 end
+    return self.WeaponData.DamageMulti
+end
+
+function ENT:GetRangeMulti()
+    if self.WeaponData == nil then return 1 end
+    if self.WeaponData.RangeMulti == nil then return 1 end
+    return self.WeaponData.RangeMulti
 end

--- a/entities/entities/ttt_basegrenade.lua
+++ b/entities/entities/ttt_basegrenade.lua
@@ -201,26 +201,26 @@ function ENT:Explode()
 	effect:SetStart(pos)
 	effect:SetOrigin(pos)
 	effect:SetScale(100)
-	effect:SetRadius(255 * self:GetRangeMulti())
+	effect:SetRadius(255 * self:GetRangeMultiplier())
 	effect:SetMagnitude(1)
 
 	util.Effect("Explosion", effect, true, true)
 
-	util.BlastDamage(self, self:GetOwner(), pos, (255 * self:GetRangeMulti()), (50 * self:GetDamageMulti()))
+	util.BlastDamage(self, self:GetOwner(), pos, (255 * self:GetRangeMultiplier()), (50 * self:GetDamageMultiplier()))
 
 	self:StartFires(pos, 10, 15, false, self:GetOwner())
 
 	--self:SetDetonateExact(0)
 end
 
-function ENT:GetDamageMulti()
+function ENT:GetDamageMultiplier()
     if self.WeaponData == nil then return 1 end
-    if self.WeaponData.DamageMulti == nil then return 1 end
-    return self.WeaponData.DamageMulti
+    if self.WeaponData.DamageMultiplier == nil then return 1 end
+    return self.WeaponData.DamageMultiplier
 end
 
-function ENT:GetRangeMulti()
+function ENT:GetRangeMultiplier()
     if self.WeaponData == nil then return 1 end
-    if self.WeaponData.RangeMulti == nil then return 1 end
-    return self.WeaponData.RangeMulti
+    if self.WeaponData.RangeMultiplier == nil then return 1 end
+    return self.WeaponData.RangeMultiplier
 end

--- a/entities/entities/ttt_smoke_grenade.lua
+++ b/entities/entities/ttt_smoke_grenade.lua
@@ -19,7 +19,7 @@ function ENT:Explode()
 
 	data:SetStart(self:GetPos())
 	data:SetMagnitude(24)
-	data:SetRadius(80) -- 10 = 1 meter
+	data:SetRadius(80 * self:GetRangeMulti()) -- 10 = 1 meter
 	data:SetColor(self:GetGrenadeColor() or 0)
 	util.Effect("tttrw_smoke", data, true, true)
 end

--- a/entities/entities/ttt_smoke_grenade.lua
+++ b/entities/entities/ttt_smoke_grenade.lua
@@ -19,7 +19,7 @@ function ENT:Explode()
 
 	data:SetStart(self:GetPos())
 	data:SetMagnitude(24)
-	data:SetRadius(80 * self:GetRangeMulti()) -- 10 = 1 meter
+	data:SetRadius(80 * self:GetRangeMultiplier()) -- 10 = 1 meter
 	data:SetColor(self:GetGrenadeColor() or 0)
 	util.Effect("tttrw_smoke", data, true, true)
 end

--- a/entities/entities/ttt_sticky_grenade.lua
+++ b/entities/entities/ttt_sticky_grenade.lua
@@ -95,9 +95,10 @@ function ENT:Think()
 	return BaseClass.Think(self)
 end
 
-local max_dist = 150
+
 
 function ENT:Explode()
+local max_dist = (150 * self:GetRangeMulti())
 	for k,v in pairs(ents.GetAll()) do
 		local top = v:GetPos() + vector_up * (v:OBBMaxs().z - v:OBBMins().z)
 		local dist = math.min(top:Distance(self:GetOrigin()), v:GetPos():Distance(self:GetOrigin()))
@@ -117,7 +118,7 @@ function ENT:Explode()
 
 			local dmg = DamageInfo()
 			dmg:SetDamageCustom(0)
-			dmg:SetDamage(150)
+			dmg:SetDamage(150 * self:GetDamageMulti())
 			dmg:ScaleDamage(1 - dist / max_dist)
 			dmg:SetInflictor(self)
 			dmg:SetAttacker(self:GetOwner())

--- a/entities/entities/ttt_sticky_grenade.lua
+++ b/entities/entities/ttt_sticky_grenade.lua
@@ -98,7 +98,7 @@ end
 
 
 function ENT:Explode()
-local max_dist = (150 * self:GetRangeMulti())
+local max_dist = (150 * self:GetRangeMultiplier())
 	for k,v in pairs(ents.GetAll()) do
 		local top = v:GetPos() + vector_up * (v:OBBMaxs().z - v:OBBMins().z)
 		local dist = math.min(top:Distance(self:GetOrigin()), v:GetPos():Distance(self:GetOrigin()))
@@ -118,7 +118,7 @@ local max_dist = (150 * self:GetRangeMulti())
 
 			local dmg = DamageInfo()
 			dmg:SetDamageCustom(0)
-			dmg:SetDamage(150 * self:GetDamageMulti())
+			dmg:SetDamage(150 * self:GetDamageMultiplier())
 			dmg:ScaleDamage(1 - dist / max_dist)
 			dmg:SetInflictor(self)
 			dmg:SetAttacker(self:GetOwner())

--- a/entities/weapons/weapon_ttt_basegrenade.lua
+++ b/entities/weapons/weapon_ttt_basegrenade.lua
@@ -16,6 +16,7 @@ SWEP.Spawnable             = true
 SWEP.Primary.Delay = 3
 
 SWEP.Primary.ClipSize = 1
+SWEP.Primary.Ammo = "none"
 SWEP.Primary.Automatic = false
 
 SWEP.ViewModel             = "models/weapons/cstrike/c_eq_flashbang.mdl"

--- a/entities/weapons/weapon_ttt_basegrenade.lua
+++ b/entities/weapons/weapon_ttt_basegrenade.lua
@@ -27,8 +27,8 @@ SWEP.GrenadeEntity = "ttt_basegrenade"
 
 SWEP.ThrowVelocity = 800
 SWEP.Bounciness = 0.3
-SWEP.DamageMulti = 1
-SWEP.RangeMulti = 1
+SWEP.DamageMultiplier = 1
+SWEP.RangeMultiplier = 1
 
 DEFINE_BASECLASS "weapon_tttbase"
 function SWEP:SetupDataTables()
@@ -63,7 +63,7 @@ function SWEP:Throw()
 
         self:TakePrimaryAmmo(1)
 		self:SetThrowStart(math.huge)
-        if !(self:CanPrimaryAttack()) then
+        if (self.Weapon:Clip1() <= 0) then
 		    hook.Run("DropCurrentWeapon", self:GetOwner())
 		    self:Remove()
         end

--- a/entities/weapons/weapon_ttt_basegrenade.lua
+++ b/entities/weapons/weapon_ttt_basegrenade.lua
@@ -15,8 +15,7 @@ SWEP.Spawnable             = true
 
 SWEP.Primary.Delay = 3
 
-SWEP.Primary.ClipSize = -1
-SWEP.Primary.Ammo = "none"
+SWEP.Primary.ClipSize = 1
 SWEP.Primary.Automatic = false
 
 SWEP.ViewModel             = "models/weapons/cstrike/c_eq_flashbang.mdl"
@@ -27,6 +26,8 @@ SWEP.GrenadeEntity = "ttt_basegrenade"
 
 SWEP.ThrowVelocity = 800
 SWEP.Bounciness = 0.3
+SWEP.DamageMulti = 1
+SWEP.RangeMulti = 1
 
 DEFINE_BASECLASS "weapon_tttbase"
 function SWEP:SetupDataTables()
@@ -59,10 +60,12 @@ function SWEP:Throw()
 		e:SetWeapon(self)
 		e:Spawn()
 
-
+        self:TakePrimaryAmmo(1)
 		self:SetThrowStart(math.huge)
-		hook.Run("DropCurrentWeapon", self:GetOwner())
-		self:Remove()
+        if !(self:CanPrimaryAttack()) then
+		    hook.Run("DropCurrentWeapon", self:GetOwner())
+		    self:Remove()
+        end
 	end
 end
 


### PR DESCRIPTION
Introduces the Damage Multi and Range Multi SWEP properties, allowing you to easily mod grenades damage values by changing these properties. Should it not be found, safely returns 1.
Also allows carrying multiple of the same grenade, while by default clipsize is one, you could theoratically modify it higher, and the grenade will only leave the player when grenades <= 0.